### PR TITLE
[UGC-3805] Backport: Fix TypeError with {{#cargo_compound_query:}} on PHP 8.0

### DIFF
--- a/tests/phpunit/integration/parserfunctions/CargoQueryIntegrationTest.php
+++ b/tests/phpunit/integration/parserfunctions/CargoQueryIntegrationTest.php
@@ -115,7 +115,16 @@ TEXT;
 		$title = Title::makeTitle( NS_TEMPLATE, $tableName );
 		$page = $this->getExistingTestPage( $title );
 
-		$table = CargoIntegrationTestUtils::getCargoTableDeclaration( $tableName, $schema );
+		$declare = "{{#cargo_declare:_table=$tableName\n";
+		foreach ( $schema as $field => $type ) {
+			$declare .= "|$field=$type\n";
+		}
+		$declare .= '}}';
+
+		// Make fields available as template parameters for easier data storage later.
+		$store = "{{#cargo_store:_table=$tableName}}";
+
+		$table = "<noinclude>$declare</noinclude>\n<includeonly>$store</includeonly>";
 
 		$this->editPage( $page, $table );
 


### PR DESCRIPTION
Cherry-pick https://gerrit.wikimedia.org/g/mediawiki/extensions/Cargo/+/414ea0d851e554bfaec7464f8d8db2b208906fde

PHP 8.0 now throws a TypeError if count() is called with something that's not an array or Countable (in this case, null). This causes Cargo compound queries to break as they utilize CargoQueryDisplayer in a way that mFieldDescriptions is left uninitialized. Fix it by explicitly specifying the empty array as the default value for field descriptions.

CargoQueryDisplayer proved challenging to test in isolation, so I created a test class with basic integration tests that allow exercising the full Cargo parser function stack, which allows testing the output from CargoQueryDisplayer.

Bug: T327339
Change-Id: I252606d54cec213585d13916798547db2c20baf5