### PR TITLE
PLATFORM-9062 | Replace use of PRIMARY_DB connection in CargoUtils, CargoAttach, CargoDeclare and CargoPageValues

### DIFF
--- a/includes/CargoRecreateDataAction.php
+++ b/includes/CargoRecreateDataAction.php
@@ -1,6 +1,7 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Permissions\PermissionManager;
 
 /**
  * Handles the 'recreatedata' action.
@@ -58,7 +59,7 @@ class CargoRecreateDataAction extends Action {
 
 		$user = $obj->getUser();
 		$permissionManager = MediaWikiServices::getInstance()->getPermissionManager();
-		if ( !$permissionManager->userCan( 'recreatecargodata', $user, $title ) ) {
+		if ( !$permissionManager->userCan( 'recreatecargodata', $user, $title, PermissionManager::RIGOR_QUICK ) ) {
 			return true;
 		}
 

--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -620,8 +620,7 @@ class CargoUtils {
 			return false;
 		}
 
-		$cdb = self::getDB();
-		return $cdb->tableExists( $tableName );
+		return CargoServices::getCargoConnectionProvider()->getConnection( DB_REPLICA )->tableExists( $tableName );
 	}
 
 	public static function fieldTypeToSQLType( $fieldType, $dbType, $size = null ) {

--- a/includes/api/CargoRecreateTablesAPI.php
+++ b/includes/api/CargoRecreateTablesAPI.php
@@ -64,7 +64,7 @@ class CargoRecreateTablesAPI extends ApiBase {
 
 	protected function getExamples() {
 		return [
-			'api.php?action=cargorecreatetables&template=City'
+			'api.php?action=cargorecreatetables&template=City',
 		];
 	}
 
@@ -76,4 +76,7 @@ class CargoRecreateTablesAPI extends ApiBase {
 		return 'csrf';
 	}
 
+	public function isWriteMode() {
+		return true;
+	}
 }

--- a/includes/parserfunctions/CargoAttach.php
+++ b/includes/parserfunctions/CargoAttach.php
@@ -1,4 +1,7 @@
 <?php
+
+use MediaWiki\MediaWikiServices;
+
 /**
  * Class for the #cargo_attach parser function.
  *
@@ -41,8 +44,10 @@ class CargoAttach {
 			return CargoUtils::formatError( wfMessage( "cargo-notable" )->parse() );
 		}
 
-		$dbw = wfGetDB( DB_MASTER );
-		$res = $dbw->select( 'cargo_tables', 'COUNT(*) AS total', [ 'main_table' => $tableName ] );
+		$res = MediaWikiServices::getInstance()
+				->getDBLoadBalancer()
+				->getConnection( DB_REPLICA )
+				->select( 'cargo_tables', 'COUNT(*) AS total', [ 'main_table' => $tableName ] );
 		$row = $res->fetchRow();
 		if ( !empty( $row ) && $row['total'] == 0 ) {
 			return CargoUtils::formatError( "Error: The specified table, \"$tableName\", does not exist." );

--- a/includes/parserfunctions/CargoDeclare.php
+++ b/includes/parserfunctions/CargoDeclare.php
@@ -308,8 +308,7 @@ class CargoDeclare {
 		}
 
 		// Validate table name.
-
-		$cdb = CargoUtils::getDB();
+		$cdb = CargoServices::getCargoConnectionProvider()->getConnection( DB_REPLICA );
 
 		foreach ( $parentTables as $extraParams ) {
 			$parentTableName = $extraParams['Name'];
@@ -359,7 +358,6 @@ class CargoDeclare {
 		// exists already - otherwise, explain that it needs to be
 		// created.
 		$text = wfMessage( 'cargo-definestable', $tableName )->text();
-		$cdb = CargoUtils::getDB();
 		if ( $cdb->tableExists( $tableName ) ) {
 			$ct = SpecialPage::getTitleFor( 'CargoTables' );
 			$pageName = $ct->getPrefixedText() . "/$tableName";

--- a/includes/specials/CargoPageValues.php
+++ b/includes/specials/CargoPageValues.php
@@ -162,8 +162,6 @@ class CargoPageValues extends IncludableSpecialPage {
 	}
 
 	public function getRowsForPageInTable( $tableName ) {
-		$cdb = CargoUtils::getDB();
-
 		$sqlQuery = new CargoSQLQuery();
 		$sqlQuery->mAliasedTableNames = [ $tableName => $tableName ];
 
@@ -197,7 +195,8 @@ class CargoPageValues extends IncludableSpecialPage {
 		$sqlQuery->mOrigAliasedFieldNames = $aliasedFieldNames;
 		$sqlQuery->setDescriptionsAndTableNamesForFields();
 		$sqlQuery->handleDateFields();
-		$sqlQuery->mWhereStr = $cdb->addIdentifierQuotes( '_pageID' ) . " = " .
+		$sqlQuery->mWhereStr = CargoServices::getCargoConnectionProvider()->getConnection( DB_REPLICA )
+				->addIdentifierQuotes( '_pageID' ) . " = " .
 			$this->mTitle->getArticleID();
 
 		$queryResults = $sqlQuery->run();

--- a/includes/specials/SpecialCargoRecreateData.php
+++ b/includes/specials/SpecialCargoRecreateData.php
@@ -64,7 +64,7 @@ class SpecialCargoRecreateData extends UnlistedSpecialPage {
 		$out->addModules( 'ext.cargo.recreatedata' );
 
 		$templateData = [];
-		$dbw = wfGetDB( DB_MASTER );
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
 		if ( $this->mTemplateTitle === null ) {
 			if ( $this->mTableName == '_pageData' ) {
 				$conds = null;
@@ -75,18 +75,18 @@ class SpecialCargoRecreateData extends UnlistedSpecialPage {
 			} else { // if ( $this->mTableName == '_ganttData' ) {
 				$conds = 'page_namespace = ' . FD_NS_GANTT;
 			}
-			$numTotalPages = $dbw->selectField( 'page', 'COUNT(*)', $conds );
+			$numTotalPages = $dbr->selectField( 'page', 'COUNT(*)', $conds );
 		} else {
 			$numTotalPages = null;
 			$templateData[] = [
 				'name' => $this->mTemplateTitle->getText(),
-				'numPages' => $this->getNumPagesThatCallTemplate( $dbw, $this->mTemplateTitle )
+				'numPages' => $this->getNumPagesThatCallTemplate( $dbr, $this->mTemplateTitle )
 			];
 		}
 
 		if ( $this->mIsDeclared ) {
 			// Get all attached templates.
-			$res = $dbw->select( 'page_props',
+			$res = $dbr->select( 'page_props',
 				[
 					'pp_page'
 				],
@@ -98,7 +98,7 @@ class SpecialCargoRecreateData extends UnlistedSpecialPage {
 			foreach ( $res as $row ) {
 				$templateID = $row->pp_page;
 				$attachedTemplateTitle = Title::newFromID( $templateID );
-				$numPages = $this->getNumPagesThatCallTemplate( $dbw, $attachedTemplateTitle );
+				$numPages = $this->getNumPagesThatCallTemplate( $dbr, $attachedTemplateTitle );
 				$attachedTemplateName = $attachedTemplateTitle->getText();
 				$templateData[] = [
 					'name' => $attachedTemplateName,
@@ -156,7 +156,7 @@ class SpecialCargoRecreateData extends UnlistedSpecialPage {
 		return true;
 	}
 
-	public function getNumPagesThatCallTemplate( IDatabase $dbw, LinkTarget $templateTitle ) {
+	public function getNumPagesThatCallTemplate( IDatabase $dbr, LinkTarget $templateTitle ) {
 		$conds = [ "tl_from=page_id" ];
 
 		// MW 1.38+ - use the normalized link target ID for fetching incoming links to this template.
@@ -170,7 +170,7 @@ class SpecialCargoRecreateData extends UnlistedSpecialPage {
 			$conds['tl_title'] = $templateTitle->getDBkey();
 		}
 
-		$res = $dbw->select(
+		$res = $dbr->select(
 			[ 'page', 'templatelinks' ],
 			'COUNT(*) AS total',
 			$conds,


### PR DESCRIPTION
## Description
Some of the actions are still using PRIMARY DB connection during the Read requests, and therefore we should replace them with use of the proper REPLICA DB. All of those cases are simple and shouldn't yield any errors when PRIMARY DB is not used to query the results.