### PR TITLE
PLATFORM-9121 | Do not swallow DB errors in Cargo query

### DIFF
--- a/includes/CargoLuaLibrary.php
+++ b/includes/CargoLuaLibrary.php
@@ -48,6 +48,8 @@ class CargoLuaLibrary extends Scribunto_LuaLibraryBase {
 			$query = CargoSQLQuery::newFromValues( $tables, $fields, $where, $join,
 				$groupBy, $having, $orderBy, $limit, $offset );
 			$rows = $query->run();
+		} catch ( \Wikimedia\Rdbms\DBError $e ) {
+			throw $e;
 		} catch ( Exception $e ) {
 			// Allow for error handling within Lua.
 			throw new Scribunto_LuaError( $e->getMessage() );

--- a/includes/parserfunctions/CargoQuery.php
+++ b/includes/parserfunctions/CargoQuery.php
@@ -114,6 +114,8 @@ class CargoQuery {
 				);
 				$queryResultsJustForResultsTitle = $sqlQueryJustForResultsTitle->run();
 			}
+		} catch ( \Wikimedia\Rdbms\DBError $e ) {
+			throw $e;
 		} catch ( Exception $e ) {
 			return CargoUtils::formatError( $e->getMessage() );
 		}


### PR DESCRIPTION
Cargo currently swallows all exceptions thrown while it is running queries, mainly because it may throw MWExceptions as validation errors which should be formatted nicely without breaking the rest of the page. However, the queries themselves may fail due to transient database issues, and Cargo wraps the resulting DBError exceptions as well without much ado. The effect is that these errors never get logged (so we don't even know how often this happens), and the error gets cached in parser cache and on the CDN, forcing people to check for and periodically purge pages with such errors.

Instead, detect and rethrow errors coming from MediaWiki's DBAL so that we can track them in our logs, and so that they do not get cached.