### PR TITLE
Backport two trivial PHP 8 compatibility fixes for Cargo

### DIFF
--- a/includes/CargoFieldDescription.php
+++ b/includes/CargoFieldDescription.php
@@ -178,7 +178,7 @@ class CargoFieldDescription {
 
 	public function getDelimiter() {
 		// Make "\n" represent a newline.
-		return str_replace( '\n', "\n", $this->mDelimiter );
+		return str_replace( '\n', "\n", $this->mDelimiter ?? '' );
 	}
 
 	public function setDelimiter( $delimiter ) {

--- a/includes/CargoFieldDescription.php
+++ b/includes/CargoFieldDescription.php
@@ -324,16 +324,12 @@ class CargoFieldDescription {
 				}
 				$individualValues = explode( $delimiter, $fieldValue );
 				foreach ( $individualValues as &$individualValue ) {
-					if ( !is_int( $individualValue ) ) {
-						$individualValue = round( $individualValue );
-					}
+					$individualValue = round( floatval( $individualValue ) );
 				}
 				$newValue = implode( $delimiter, $individualValues );
 			} else {
 				$newValue = str_replace( $wgCargoDigitGroupingCharacter, '', $fieldValue );
-				if ( !is_int( $newValue ) ) {
-					$newValue = round( $newValue );
-				}
+				$newValue = round( floatval( $newValue ) );
 			}
 		} elseif ( $fieldType == 'Float' || $fieldType == 'Rating' ) {
 			// Remove digit-grouping character, and change


### PR DESCRIPTION
The second one in particular is important as it apparently causes hard errors for certain inputs, preventing data from being stored.