### PR TITLE
PLATFORM-9121 | Properly handle setting character set for connections

### DIFF
--- a/includes/CargoConnectionProvider.php
+++ b/includes/CargoConnectionProvider.php
@@ -169,6 +169,17 @@ class CargoConnectionProvider {
 	 * @param IDatabase $dbw Database connection handle.
 	 */
 	private static function setClientCharacterSet( IDatabase $dbw ): void {
+		// For DBConnRefs wrapping a lazy-initialized connection handle,
+		// we need to unwrap that connection handle to set the character set.
+		if ( $dbw instanceof DBConnRef ) {
+			// Force open the database connection so that we can obtain the underlying native connection handle.
+			$dbw->ping();
+
+			$ref = new ReflectionProperty( $dbw, 'conn' );
+			$ref->setAccessible( true );
+			$dbw = $ref->getValue( $dbw );
+		}
+
 		if ( $dbw instanceof DatabaseMysqli ) {
 			// Force open the database connection so that we can obtain the underlying native connection handle.
 			$dbw->ping();


### PR DESCRIPTION
Now that we may use MW's LB abstractions for managing Cargo DB connections on some cases, we must account for the fact that these tend to return DBConnRef instances instead of raw connection handles. Unwrap DBConnRefs accordingly so that we can operate on the backing connection directly when setting the charset.