### PR TITLE
End the ungodly racket made by PHP deprecation warnings

### DIFF
--- a/drilldown/CargoSpecialDrilldown.php
+++ b/drilldown/CargoSpecialDrilldown.php
@@ -36,7 +36,7 @@ class CargoSpecialDrilldown extends IncludableSpecialPage {
 		$this->setHeaders();
 		$out->addModules( 'ext.cargo.drilldown' );
 
-		$queryparts = explode( '/', $query, 1 );
+		$queryparts = explode( '/', $query ?? '', 1 );
 		$mainTable = $queryparts[0] ?? '';
 
 		// If no table was specified, go with the first table,

--- a/includes/CargoSQLQuery.php
+++ b/includes/CargoSQLQuery.php
@@ -1049,11 +1049,11 @@ class CargoSQLQuery {
 				$replacement = "$fieldTableAlias._value";
 
 				if ( $foundMatch1 ) {
-					$this->mGroupByStr = preg_replace( $pattern1, $replacement, $this->mGroupByStr );
-					$this->mHavingStr = preg_replace( $pattern1, $replacement, $this->mHavingStr );
+					$this->mGroupByStr = preg_replace( $pattern1, $replacement, $this->mGroupByStr ?? '' );
+					$this->mHavingStr = preg_replace( $pattern1, $replacement, $this->mHavingStr ?? '' );
 				} elseif ( $foundMatch2 ) {
-					$this->mGroupByStr = preg_replace( $pattern2, $replacement, $this->mGroupByStr );
-					$this->mHavingStr = preg_replace( $pattern2, $replacement, $this->mHavingStr );
+					$this->mGroupByStr = preg_replace( $pattern2, $replacement, $this->mGroupByStr ?? '' );
+					$this->mHavingStr = preg_replace( $pattern2, $replacement, $this->mHavingStr ?? '' );
 				}
 			}
 		}

--- a/includes/CargoSQLQuery.php
+++ b/includes/CargoSQLQuery.php
@@ -52,6 +52,11 @@ class CargoSQLQuery {
 			throw new MWException( "At least one table must be specified." );
 		}
 
+		// Needed to avoid various warnings.
+		if ( $whereStr === null ) {
+			$whereStr = '';
+		}
+
 		self::validateValues( $tablesStr, $fieldsStr, $whereStr, $joinOnStr, $groupByStr,
 			$havingStr, $orderByStr, $limitStr, $offsetStr, $allowFieldEscaping );
 

--- a/includes/formats/CargoListFormat.php
+++ b/includes/formats/CargoListFormat.php
@@ -33,7 +33,7 @@ class CargoListFormat extends CargoDisplayFormat {
 			if ( !array_key_exists( $fieldName, $row ) ) {
 				continue;
 			}
-			$fieldValue = $row[$fieldName];
+			$fieldValue = $row[$fieldName] ?? '';
 			if ( trim( $fieldValue ) == '' ) {
 				continue;
 			}

--- a/includes/formats/CargoTemplateFormat.php
+++ b/includes/formats/CargoTemplateFormat.php
@@ -28,10 +28,9 @@ class CargoTemplateFormat extends CargoDisplayFormat {
 				// because it's the only one that uses the
 				// unformatted values - the formatted values
 				// do this HTML-encoding on their own.
+				$value = $row[$fieldName] ?? '';
 				if ( $fieldDescription->mType == 'Wikitext' || $fieldDescription->mType == 'Wikitext string' ) {
-					$value = htmlspecialchars_decode( $row[$fieldName] );
-				} else {
-					$value = $row[$fieldName];
+					$value = htmlspecialchars_decode( $value );
 				}
 				// Escape pipes within the values so that they
 				// aren't interpreted as template pipes.

--- a/includes/parserfunctions/CargoStore.php
+++ b/includes/parserfunctions/CargoStore.php
@@ -548,7 +548,9 @@ class CargoStore {
 				$fieldSize = $fieldDescription->getFieldSize();
 			}
 
-			if ( $fieldValue === '' ) {
+			if ( $fieldValue === null ) {
+				// Do nothing.
+			} elseif ( $fieldValue === '' ) {
 				// Needed for correct SQL handling of blank values, for some reason.
 				$fieldValue = null;
 			} elseif ( $fieldSize != null && strlen( $fieldValue ) > $fieldSize ) {

--- a/includes/parserfunctions/CargoStore.php
+++ b/includes/parserfunctions/CargoStore.php
@@ -400,7 +400,7 @@ class CargoStore {
 			if ( $fieldDescription->mIsList ) {
 				$fieldTableName = $tableName . '__' . $fieldName;
 				$delimiter = $fieldDescription->getDelimiter();
-				$individualValues = explode( $delimiter, $tableFieldValues[$fieldName] );
+				$individualValues = explode( $delimiter, $tableFieldValues[$fieldName] ?? '' );
 				$valueNum = 1;
 				foreach ( $individualValues as $individualValue ) {
 					$individualValue = trim( $individualValue );


### PR DESCRIPTION
Our version of Cargo is missing several PHP > 8.1 compatibility patches, which causes it to emit a significant amount of deprecation notices. This is especially noticeable and annoying on devboxes, where these spawn giant XDebug error boxes and interfere with testing. So, backport the relevant fixes to silence the logs.