### PR TITLE
PLATFORM-9297 | Don't double-escape single quotes in Cargo results

### DIFF
--- a/includes/CargoSQLQuery.php
+++ b/includes/CargoSQLQuery.php
@@ -1616,7 +1616,7 @@ class CargoSQLQuery {
 					// It's a string.
 					// Escape any HTML, to avoid JavaScript
 					// injections and the like.
-					$resultsRow[$alias] = htmlspecialchars( $curValue );
+					$resultsRow[$alias] = htmlspecialchars( $curValue, ENT_COMPAT );
 				}
 			}
 			$resultArray[] = $resultsRow;


### PR DESCRIPTION
Cargo has been double-escaping query results since 2e587bab444d82d939cd376b2fb08f0eab95c854. On PHP 8.2, this is causing single quotes in benign outputs such as "Cox's Bazaar" to be double-escaped, as htmlspecialchars() on PHP 8.1 and newer escapes single quotes by default.

The double-escaping can and should be investigated and fixed upstream, but to unblock our PHP 8.2 migration, simply switch back the htmlspecialchars() behavior to the original so that the single quotes do not get double-escaped.