### PR TITLE
Handle greater validation of SQL field names in MW 1.42+

### DIFF
--- a/includes/CargoSQLQuery.php
+++ b/includes/CargoSQLQuery.php
@@ -220,6 +220,10 @@ class CargoSQLQuery {
 			if ( count( $fieldStringParts ) == 2 ) {
 				$fieldName = trim( $fieldStringParts[0] );
 				$alias = trim( $fieldStringParts[1] );
+				// Validate alias.
+				if ( strpos( $alias, '.' ) !== false || strpos( $alias, '"' ) !== false || strpos( $alias, '\'' ) !== false ) {
+					throw new MWException( "Error: invalid field alias \"$alias\"; aliases cannot contain dots or quotes." );
+				}
 			} else {
 				$fieldName = $fieldString;
 				// Might as well change underscores to spaces
@@ -236,6 +240,11 @@ class CargoSQLQuery {
 				} else {
 					$alias = $realFieldName;
 				}
+				// If this is just the field name being used as
+				// the alias, and it contains forbidden
+				// characters, don't throw an error - just
+				// replace those characters with spaces.
+				$alias = str_replace( [ '.', '"', '\'' ], ' ', $alias );
 			}
 			if ( !$alias ) {
 				$blankAliasCount++;


### PR DESCRIPTION
To prevent the not-totally-helpful "Identifier must not contain quote, dot or null characters" exception being thrown by MW.

Change-Id: I31ec62c8a94a880f51cfc51af145d169155e09b1