### PR TITLE
fix(UGC-6792): scope CargoStore::$settings during save to prevent leaks

### DIFF
--- a/CargoHooks.php
+++ b/CargoHooks.php
@@ -289,12 +289,9 @@ class CargoHooks {
         // (e.g. jobs/Scribunto after move/save), leading to unintended storeTable() behavior
         // or duplicates. We must scope the setting to THIS single parse only.
         // @see https://fandom.atlassian.net/browse/UGC-6792
-        $previousSettings = CargoStore::$settings;
-        CargoStore::$settings = array_merge( $previousSettings, [
+        self::withCargoSettings( [
             'origin' => 'page save',
-        ] );
-
-		try {
+        ], function() use ( $wikiPage, $revisionRecord ) {
             CargoUtils::parsePageForStorage(
                 $wikiPage->getTitle(),
                 $revisionRecord->getContent( SlotRecord::MAIN )->getText()
@@ -302,9 +299,7 @@ class CargoHooks {
             // Also, save data to any relevant "special tables", if they
             // exist.
             self::saveToSpecialTables( $wikiPage->getTitle() );
-        } finally {
-            CargoStore::$settings = $previousSettings;
-        }
+        } );
         // Fandom-end
 
 		// Invalidate pages that reference this page in their Cargo query results.
@@ -398,47 +393,25 @@ class CargoHooks {
 		}
 		$dbw = CargoUtils::getMainDBForWrite();
 		$cdb = CargoUtils::getDB();
-		// Fandom-start
-		$cdb->startAtomic( __METHOD__ );
-		// Fandom-end
 
-		$res = $dbw->select( 'cargo_pages', 'table_name', [ 'page_id' => $pageid ], __METHOD__ );
-		foreach ( $res as $row ) {
-			$curMainTable = $row->table_name;
-			$cdb->update( $curMainTable,
-				[
-					$cdb->addIdentifierQuotes( '_pageName' ) => $newPageName,
-					$cdb->addIdentifierQuotes( '_pageTitle' ) => $newPageTitle,
-					$cdb->addIdentifierQuotes( '_pageNamespace' ) => $newPageNamespace
-				],
-				[ $cdb->addIdentifierQuotes( '_pageID' ) => $pageid ],
-				__METHOD__
-			);
-		}
-
-		// Update the page title in the "general data" tables.
-		$generalTables = [ '_pageData', '_fileData' ];
-		foreach ( $generalTables as $generalTable ) {
-			if ( $cdb->tableExists( $generalTable, __METHOD__ ) ) {
-				// Update in the replacement table, if one exists.
-				if ( $cdb->tableExists( $generalTable . '__NEXT', __METHOD__ ) ) {
-					$generalTable = $generalTable . '__NEXT';
-				}
-				$cdb->update( $generalTable,
-					[
-						$cdb->addIdentifierQuotes( '_pageName' ) => $newPageName,
-						$cdb->addIdentifierQuotes( '_pageTitle' ) => $newPageTitle,
-						$cdb->addIdentifierQuotes( '_pageNamespace' ) => $newPageNamespace
-					],
-					[ $cdb->addIdentifierQuotes( '_pageID' ) => $pageid ],
-					__METHOD__
-				);
-			}
-		}
-
-		// Fandom-start
-		$cdb->endAtomic( __METHOD__ );
-		// Fandom-end
+        // Fandom-start
+        // Issue: for example lol.fandom.com wiki has dynamic values based on page title in Cargo fields
+        // They cannot be easily updated on page move, so we delete and re-store all data for the page
+        // This will mitigate issues with incorrect data displayed in Cargo queries after page move
+        self::deletePageFromSystem( $pageid );
+        self::withCargoSettings( [
+            'origin' => 'page move',
+        ], function() use ( $new ) {
+            $wikiPage = CargoUtils::makeWikiPage( $new );
+            CargoUtils::parsePageForStorage(
+                $new,
+                $wikiPage->getContent( SlotRecord::MAIN )->getText()
+            );
+            // Also, save data to any relevant "special tables", if they
+            // exist.
+            self::saveToSpecialTables( $wikiPage->getTitle() );
+        } );
+        // Fandom-end
 
 		// Save data for the original page (now a redirect).
 		if ( $redirid != 0 ) {
@@ -447,6 +420,19 @@ class CargoHooks {
 			CargoPageData::storeValuesForPage( $oldTitle, $useReplacementTable );
 		}
 	}
+
+    // Fandom-start
+    private static function withCargoSettings( array $settings, callable $fn ) {
+        $previousSettings = CargoStore::$settings;
+        CargoStore::$settings = $settings;
+        try {
+            return $fn();
+        }
+        finally {
+            CargoStore::$settings = $previousSettings;
+        }
+    }
+    // Fandom-end
 
 	/**
 	 * Deletes all Cargo data about a page, if the page has been deleted.

--- a/CargoHooks.php
+++ b/CargoHooks.php
@@ -283,15 +283,29 @@ class CargoHooks {
 		// Even though the page will get parsed again after the save,
 		// we need to parse it here anyway, for the settings we
 		// added to remain set.
-		CargoStore::$settings['origin'] = 'page save';
-		CargoUtils::parsePageForStorage(
-			$wikiPage->getTitle(),
-			$revisionRecord->getContent( SlotRecord::MAIN )->getText()
-		);
 
-		// Also, save data to any relevant "special tables", if they
-		// exist.
-		self::saveToSpecialTables( $wikiPage->getTitle() );
+        // Fandom-start
+        // Issue: CargoStore::$settings was set globally and leaked into subsequent parses
+        // (e.g. jobs/Scribunto after move/save), leading to unintended storeTable() behavior
+        // or duplicates. We must scope the setting to THIS single parse only.
+        // @see https://fandom.atlassian.net/browse/UGC-6792
+        $previousSettings = CargoStore::$settings;
+        CargoStore::$settings = array_merge( $previousSettings, [
+            'origin' => 'page save',
+        ] );
+
+		try {
+            CargoUtils::parsePageForStorage(
+                $wikiPage->getTitle(),
+                $revisionRecord->getContent( SlotRecord::MAIN )->getText()
+            );
+            // Also, save data to any relevant "special tables", if they
+            // exist.
+            self::saveToSpecialTables( $wikiPage->getTitle() );
+        } finally {
+            CargoStore::$settings = $previousSettings;
+        }
+        // Fandom-end
 
 		// Invalidate pages that reference this page in their Cargo query results.
 		CargoBackLinks::purgePagesThatQueryThisPage( $pageID );

--- a/CargoHooks.php
+++ b/CargoHooks.php
@@ -284,23 +284,23 @@ class CargoHooks {
 		// we need to parse it here anyway, for the settings we
 		// added to remain set.
 
-        // Fandom-start
-        // Issue: CargoStore::$settings was set globally and leaked into subsequent parses
-        // (e.g. jobs/Scribunto after move/save), leading to unintended storeTable() behavior
-        // or duplicates. We must scope the setting to THIS single parse only.
-        // @see https://fandom.atlassian.net/browse/UGC-6792
-        self::withCargoSettings( [
-            'origin' => 'page save',
-        ], function() use ( $wikiPage, $revisionRecord ) {
-            CargoUtils::parsePageForStorage(
-                $wikiPage->getTitle(),
-                $revisionRecord->getContent( SlotRecord::MAIN )->getText()
-            );
-            // Also, save data to any relevant "special tables", if they
-            // exist.
-            self::saveToSpecialTables( $wikiPage->getTitle() );
-        } );
-        // Fandom-end
+		// Fandom-start
+		// Issue: CargoStore::$settings was set globally and leaked into subsequent parses
+		// (e.g. jobs/Scribunto after move/save), leading to unintended storeTable() behavior
+		// or duplicates. We must scope the setting to THIS single parse only.
+		// @see https://fandom.atlassian.net/browse/UGC-6792
+		self::withCargoSettings( [
+			'origin' => 'page save',
+		], function () use ( $wikiPage, $revisionRecord ) {
+			CargoUtils::parsePageForStorage(
+				$wikiPage->getTitle(),
+				$revisionRecord->getContent( SlotRecord::MAIN )->getText()
+			);
+			// Also, save data to any relevant "special tables", if they
+			// exist.
+			self::saveToSpecialTables( $wikiPage->getTitle() );
+		} );
+		// Fandom-end
 
 		// Invalidate pages that reference this page in their Cargo query results.
 		CargoBackLinks::purgePagesThatQueryThisPage( $pageID );
@@ -394,24 +394,24 @@ class CargoHooks {
 		$dbw = CargoUtils::getMainDBForWrite();
 		$cdb = CargoUtils::getDB();
 
-        // Fandom-start
-        // Issue: for example lol.fandom.com wiki has dynamic values based on page title in Cargo fields
-        // They cannot be easily updated on page move, so we delete and re-store all data for the page
-        // This will mitigate issues with incorrect data displayed in Cargo queries after page move
-        self::deletePageFromSystem( $pageid );
-        self::withCargoSettings( [
-            'origin' => 'page move',
-        ], function() use ( $new ) {
-            $wikiPage = CargoUtils::makeWikiPage( $new );
-            CargoUtils::parsePageForStorage(
-                $new,
-                $wikiPage->getContent( SlotRecord::MAIN )->getText()
-            );
-            // Also, save data to any relevant "special tables", if they
-            // exist.
-            self::saveToSpecialTables( $wikiPage->getTitle() );
-        } );
-        // Fandom-end
+		// Fandom-start
+		// Issue: for example lol.fandom.com wiki has dynamic values based on page title in Cargo fields
+		// They cannot be easily updated on page move, so we delete and re-store all data for the page
+		// This will mitigate issues with incorrect data displayed in Cargo queries after page move
+		self::deletePageFromSystem( $pageid );
+		self::withCargoSettings( [
+			'origin' => 'page move',
+		], function () use ( $new ) {
+			$wikiPage = CargoUtils::makeWikiPage( $new );
+			CargoUtils::parsePageForStorage(
+				$new,
+				$wikiPage->getContent( SlotRecord::MAIN )->getText()
+			);
+			// Also, save data to any relevant "special tables", if they
+			// exist.
+			self::saveToSpecialTables( $wikiPage->getTitle() );
+		} );
+		// Fandom-end
 
 		// Save data for the original page (now a redirect).
 		if ( $redirid != 0 ) {
@@ -421,18 +421,18 @@ class CargoHooks {
 		}
 	}
 
-    // Fandom-start
-    private static function withCargoSettings( array $settings, callable $fn ) {
-        $previousSettings = CargoStore::$settings;
-        CargoStore::$settings = $settings;
-        try {
-            return $fn();
-        }
-        finally {
-            CargoStore::$settings = $previousSettings;
-        }
-    }
-    // Fandom-end
+	// Fandom-start
+	private static function withCargoSettings( array $settings, callable $fn ) {
+		$previousSettings = CargoStore::$settings;
+		CargoStore::$settings = $settings;
+		try {
+			return $fn();
+		} finally {
+			CargoStore::$settings = $previousSettings;
+		}
+	}
+
+	// Fandom-end
 
 	/**
 	 * Deletes all Cargo data about a page, if the page has been deleted.

--- a/CargoHooks.php
+++ b/CargoHooks.php
@@ -421,7 +421,7 @@ class CargoHooks {
 		}
 	}
 
-	// Fandom-start
+	/** Fandom-start */
 	private static function withCargoSettings( array $settings, callable $fn ) {
 		$previousSettings = CargoStore::$settings;
 		CargoStore::$settings = $settings;
@@ -432,7 +432,7 @@ class CargoHooks {
 		}
 	}
 
-	// Fandom-end
+	/** Fandom-end */
 
 	/**
 	 * Deletes all Cargo data about a page, if the page has been deleted.

--- a/includes/CargoRecreateDataAction.php
+++ b/includes/CargoRecreateDataAction.php
@@ -1,8 +1,8 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
-use MediaWiki\Title\Title;
 use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Title\Title;
 
 /**
  * Handles the 'recreatedata' action.

--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -926,14 +926,14 @@ class CargoUtils {
 			$createSQLSuffixes[] = "ROW_FORMAT=$cargoDBRowFormat";
 		}
 		$createSQL .= " " . implode( ', ', $createSQLSuffixes );
-        // Fandom-start: set utf8mb4 character set for Cargo tables (UGC-4625).
-        // These tables cannot use the binary charset that other MediaWiki tables use
-        // due to the need to support natural ordering of varchar fields as well as
-        // SQL functions such as REGEXP_LIKE() that do not support binary fields.
-        // Historically, these tables were created with the 3-byte utf8 character set,
-        // which is not sufficient for some characters, such as emoji.
-        $createSQL .= " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
-        // Fandom-end
+		// Fandom-start: set utf8mb4 character set for Cargo tables (UGC-4625).
+		// These tables cannot use the binary charset that other MediaWiki tables use
+		// due to the need to support natural ordering of varchar fields as well as
+		// SQL functions such as REGEXP_LIKE() that do not support binary fields.
+		// Historically, these tables were created with the 3-byte utf8 character set,
+		// which is not sufficient for some characters, such as emoji.
+		$createSQL .= " CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+		// Fandom-end
 		$cdb->query( $createSQL, __METHOD__ );
 
 		// Add an index for any field that's not of type Text,

--- a/includes/parserfunctions/CargoStore.php
+++ b/includes/parserfunctions/CargoStore.php
@@ -401,7 +401,8 @@ class CargoStore {
 			[
 				'TABLE_NAME' => $cdb->tablePrefix() . $tableName,
 				'TABLE_SCHEMA' => $cdb->getDBname(),
-			]
+			],
+            __METHOD__
 		);
 		if ( $row == false || $row->AUTO_INCREMENT == null ) {
 			// Set _ID manually if we're not using AUTO_INCREMENT.

--- a/includes/parserfunctions/CargoStore.php
+++ b/includes/parserfunctions/CargoStore.php
@@ -402,7 +402,7 @@ class CargoStore {
 				'TABLE_NAME' => $cdb->tablePrefix() . $tableName,
 				'TABLE_SCHEMA' => $cdb->getDBname(),
 			],
-            __METHOD__
+			__METHOD__
 		);
 		if ( $row == false || $row->AUTO_INCREMENT == null ) {
 			// Set _ID manually if we're not using AUTO_INCREMENT.

--- a/includes/specials/CargoTables.php
+++ b/includes/specials/CargoTables.php
@@ -9,7 +9,6 @@
  */
 
 use MediaWiki\Html\Html;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 
 class CargoTables extends IncludableSpecialPage {


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/UGC-6792
* https://fandom.atlassian.net/browse/UGC-6784
* https://github.com/Wikia/unified-platform/pull/22382

## Description
Root issue: When saving pages `CargoStore::$settings['origin']` is set to `'page save'` so `#cargo_store` parser functions knows it’s running from a save. That global state leaked into subsequent parses (e.g., follow-up jobs, Scribunto invocations, post-move parsing), causing unintended storeTable() behavior (skips/inserts/duplicates depending on conditions).
Second issue: only updating _pageName/_pageTitle/_pageNamespace on move is insufficient for wikis where many Cargo fields are computed from the title; a full delete-and-re-store on the new title is required to repopulate all dependent fields.

## Acceptance Criteria
- [ ] test for new code.

## Who might be interested
