### PR TITLE
UGC-6783: Optimize Special:CargoTabels; remove API permission check (from update); revert ROAA

### DIFF
--- a/CargoHooks.php
+++ b/CargoHooks.php
@@ -69,9 +69,17 @@ class CargoHooks {
 		if ( $title->isSpecialPage() ) {
 			$cargoSpecialPageIDs = [
 				SpecialPage::getTitleFor( 'CargoQuery' )->getDBkey(),
-				SpecialPage::getTitleFor( 'CargoExport' )->getDBkey()
+				SpecialPage::getTitleFor( 'CargoExport' )->getDBkey(),
+				SpecialPage::getTitleFor( 'Drilldown' )->getDBkey()
 			];
-			if ( !in_array( $title->getDBkey(), $cargoSpecialPageIDs ) ) {
+			$titleDBKey = $title->getDBkey();
+			// Handle pages of the form Special:Drilldown/TableName
+			$lastSlashPos = strrpos( $titleDBKey, '/' );
+			if ( $lastSlashPos !== false ) {
+				$titleDBKey = substr( $titleDBKey, 0, $lastSlashPos );
+			}
+
+			if ( !in_array( $titleDBKey, $cargoSpecialPageIDs ) ) {
 				return;
 			}
 		}

--- a/drilldown/CargoAppliedFilter.php
+++ b/drilldown/CargoAppliedFilter.php
@@ -56,7 +56,7 @@ class CargoAppliedFilter {
 	 * combination to an SQL "WHERE" clause.
 	 */
 	public function checkSQL() {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		if ( $this->filter->fieldDescription->mIsList ) {
 			$fieldTableName = $this->filter->tableName . '__' . $this->filter->name;
@@ -176,7 +176,7 @@ class CargoAppliedFilter {
 	}
 
 	public function getQueryParts( $mainTableName ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		$tableNames = [];
 		$conds = [];
@@ -228,7 +228,7 @@ class CargoAppliedFilter {
 		}
 		$table = [ $tableAlias => $tableName ];
 
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		$res = $cdb->select( $table, "DISTINCT " . $cdb->addIdentifierQuotes( $value_field ) );
 		foreach ( $res as $row ) {
 			$possible_values[] = $row->$value_field;

--- a/drilldown/CargoDrilldownHierarchy.php
+++ b/drilldown/CargoDrilldownHierarchy.php
@@ -12,7 +12,7 @@ class CargoDrilldownHierarchy extends CargoHierarchyTree {
 
 	public static function computeNodeCountByFilter( $node, $f, $fullTextSearchTerm, $appliedFilters,
 			$mainTableAlias = null, $tableNames = [], $joinConds = [] ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		[ $tableNames, $conds, $joinConds ] = $f->getQueryParts( $fullTextSearchTerm,
 			$appliedFilters, $tableNames, $joinConds );
 		if ( $f->fieldDescription->mIsList ) {

--- a/drilldown/CargoDrilldownPage.php
+++ b/drilldown/CargoDrilldownPage.php
@@ -233,7 +233,7 @@ END;
 
 END;
 		}
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		foreach ( $tables as $table ) {
 			if ( $cdb->tableExists( $table, __METHOD__ ) == false ) {
 				$text .= '<li class="tableName error">' . $table . "</li>";
@@ -1414,7 +1414,7 @@ END;
 	}
 
 	public function getInitialQueryParts() {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		if ( $this->isReplacementTable ) {
 			$mainTableName = $this->tableName . '__NEXT';
 		} else {
@@ -1550,7 +1550,7 @@ END;
 	}
 
 	public function getQueryInfo() {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		[ $tableNames, $joinConds ] = $this->getInitialQueryParts();
 
@@ -1908,7 +1908,7 @@ END;
 
 	public static function getFullTextSearchQueryParts( $searchTerm, $mainTableName, $mainTableAlias,
 			$searchablePages, $searchableFiles ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		$tableNames = [];
 		$conds = [];
@@ -1969,7 +1969,7 @@ END;
 	}
 
 	public function getOrderFields() {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		return [ CargoUtils::escapedFieldName( $cdb, [ $this->tableAlias => $this->tableName ],
 			'_pageName' ) ];
 	}

--- a/drilldown/CargoFilter.php
+++ b/drilldown/CargoFilter.php
@@ -71,7 +71,7 @@ class CargoFilter {
 			return null;
 		}
 
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		$dbType = $cdb->getType();
 		if ( $this->fieldDescription->mIsList ) {
 			$fieldTableName = $this->tableName . '__' . $this->name;
@@ -126,7 +126,7 @@ class CargoFilter {
 	 */
 	public function getQueryParts( $fullTextSearchTerm, $appliedFilters, $tableNames = [],
 			$joinConds = [] ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		if ( !$tableNames ) {
 			$tableNames = [ $this->tableName => $this->tableAlias ];
@@ -195,7 +195,7 @@ class CargoFilter {
 	 */
 	public function getTimePeriodValues( $fullTextSearchTerm, $appliedFilters, $mainTableAlias = null,
 			$tableNames = [], $joinConds = [] ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		$possible_dates = [];
 		if ( $this->fieldDescription->mIsList ) {
@@ -309,7 +309,7 @@ class CargoFilter {
 	 */
 	public function getAllValues( $fullTextSearchTerm, $appliedFilters, $isApplied = false,
 			$mainTableAlias = null, $tableNames = [], $join_conds = [] ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		[ $tableNames, $conds, $joinConds ] = $this->getQueryParts( $fullTextSearchTerm,
 			$appliedFilters, $tableNames, $join_conds );

--- a/drilldown/CargoSpecialDrilldown.php
+++ b/drilldown/CargoSpecialDrilldown.php
@@ -62,7 +62,7 @@ class CargoSpecialDrilldown extends IncludableSpecialPage {
 			$mainTable .= '__NEXT';
 		}
 
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		// This check is necessary because getTableSchemas(), below,
 		// for some reason returns a false positive when an alternate

--- a/includes/CargoConnectionProvider.php
+++ b/includes/CargoConnectionProvider.php
@@ -57,13 +57,6 @@ class CargoConnectionProvider {
 	 * Get a database connection for accessing Cargo data.
 	 */
 	public function getConnection( int $dbType ): IDatabase {
-		if ( $dbType === 1_000_000 ) {
-			$dbType = in_array(
-				\MediaWiki\MediaWikiServices::getInstance()->getMainConfig()->get( 'CityId' ),
-				[ 2293615, 3743000 ] // PLATFORM-11312: disable ROAA on lol.fandom.com
-			) ? DB_PRIMARY : DB_REPLICA;
-		}
-
 		$cluster = $this->serviceOptions->get( 'CargoDBCluster' );
 
 		// If a cluster is specified, let MediaWiki's DBAL manage the lifecycle of Cargo-related connections.

--- a/includes/CargoConnectionProvider.php
+++ b/includes/CargoConnectionProvider.php
@@ -60,7 +60,7 @@ class CargoConnectionProvider {
 		if ( $dbType === 1_000_000 ) {
 			$dbType = in_array(
 				\MediaWiki\MediaWikiServices::getInstance()->getMainConfig()->get( 'CityId' ),
-				[ 2293615, 3743000, 3621839 ] // PLATFORM-11312: disable ROAA on lol.fandom.com and restricted-lol-143.fandom.com
+				[ 2293615, 3743000 ] // PLATFORM-11312: disable ROAA on lol.fandom.com
 			) ? DB_PRIMARY : DB_REPLICA;
 		}
 

--- a/includes/CargoQueryPage.php
+++ b/includes/CargoQueryPage.php
@@ -112,7 +112,7 @@ class CargoQueryPage extends QueryPage {
 
 		// Field aliases need to have quotes placed around them
 		// before running the query.
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		$aliasedFieldNames = [];
 		foreach ( $this->sqlQuery->mAliasedFieldNames as $alias => $fieldName ) {
 			// If it's really a field name, add quotes around it.

--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -650,7 +650,7 @@ class CargoUtils {
 			return false;
 		}
 
-		$cdb = self::getDB( 1_000_000 );
+		$cdb = self::getDB( DB_REPLICA );
 		return $cdb->tableExists( $tableName, __METHOD__ );
 	}
 

--- a/includes/CargoUtils.php
+++ b/includes/CargoUtils.php
@@ -123,6 +123,26 @@ class CargoUtils {
 		$out->addWikiTextAsInterface( '<div class="error">' . $message->plain() . '</div>' );
 	}
 
+	public static function getExistingTables( $tableNames ) {
+		$dbr = self::getMainDBForRead();
+		$res = $dbr->newSelectQueryBuilder()
+			->select( 'table_name' )
+			->table( 'information_schema.tables' )
+			->where( [
+				'table_schema' => $dbr->getDBname(),
+				'table_name' => $tableNames
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		$existingTables = [];
+		foreach ( $res as $row ) {
+			$existingTables[ $row->table_name ] = true;
+		}
+
+		return $existingTables;
+	}
+
 	public static function getTables() {
 		$tableNames = [];
 		$dbr = self::getMainDBForRead();

--- a/includes/api/CargoQueryAPI.php
+++ b/includes/api/CargoQueryAPI.php
@@ -13,8 +13,6 @@ class CargoQueryAPI extends ApiBase {
 	}
 
 	public function execute() {
-		$this->checkUserRightsAny( 'runcargoqueries' );
-
 		$params = $this->extractRequestParams();
 		$tablesStr = $params['tables'];
 		$fieldsStr = $params['fields'];

--- a/includes/api/CargoQueryAutocompleteAPI.php
+++ b/includes/api/CargoQueryAutocompleteAPI.php
@@ -16,8 +16,6 @@ class CargoQueryAutocompleteAPI extends ApiBase {
 	}
 
 	public function execute() {
-		$this->checkUserRightsAny( 'runcargoqueries' );
-
 		$params = $this->extractRequestParams();
 		$substr = $params['search'];
 		$tables = $params['tables'];

--- a/includes/specials/CargoPageValues.php
+++ b/includes/specials/CargoPageValues.php
@@ -47,7 +47,7 @@ class CargoPageValues extends IncludableSpecialPage {
 
 		$tableNames = [];
 
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		if ( $cdb->tableExists( '_pageData__NEXT', __METHOD__ ) ) {
 			$tableNames[] = '_pageData__NEXT';
 		} elseif ( $cdb->tableExists( '_pageData', __METHOD__ ) ) {
@@ -179,7 +179,7 @@ class CargoPageValues extends IncludableSpecialPage {
 	}
 
 	public function getRowsForPageInTable( $tableName ) {
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 
 		$sqlQuery = new CargoSQLQuery();
 		$sqlQuery->mAliasedTableNames = [ $tableName => $tableName ];

--- a/includes/specials/CargoTables.php
+++ b/includes/specials/CargoTables.php
@@ -113,7 +113,7 @@ class CargoTables extends IncludableSpecialPage {
 		$out->addHTML( $structureDesc );
 
 		// Then, display a count.
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		$numRows = $cdb->selectRowCount( $tableName, '*', null, __METHOD__ );
 		$numRowsMessage =
 			$this->msg( 'cargo-cargotables-totalrows' )->numParams( $numRows )->parse();
@@ -490,7 +490,7 @@ class CargoTables extends IncludableSpecialPage {
 		 * Fandom change - end
 		 */
 
-		$cdb = CargoUtils::getDB( 1_000_000 );
+		$cdb = CargoUtils::getDB( DB_REPLICA );
 		$tableNames = CargoUtils::getTables();
 
 		// Move the "special" tables into a separate array.

--- a/includes/specials/CargoTables.php
+++ b/includes/specials/CargoTables.php
@@ -502,17 +502,28 @@ class CargoTables extends IncludableSpecialPage {
 			}
 		}
 
+		// Fandom-start
+		// Optimize table existence checks to avoid N+1 queries.
+		// Pre-fetch the existence status of all potential replacement tables in a single query.
+		$replacementTables = [];
+		foreach ( $tableNames as $tableIndex => $tableName ) {
+			$possibleReplacementTable = $tableName . '__NEXT';
+			$replacementTables[] = $possibleReplacementTable;
+		}
+		$existingReplacementTables = CargoUtils::getExistingTables( $replacementTables );
+
 		// reorder table list so tables with replacements are first,
 		// but only if the preference is set to do so
 		if ( $wgCargoTablesPrioritizeReplacements ) {
 			foreach ( $tableNames as $tableIndex => $tableName ) {
 				$possibleReplacementTable = $tableName . '__NEXT';
-				if ( $cdb->tableExists( $possibleReplacementTable, __METHOD__ ) ) {
+				if ( isset( $existingReplacementTables[$possibleReplacementTable] ) ) {
 					unset( $tableNames[$tableIndex] );
 					array_unshift( $tableNames, $tableName );
 				}
 			}
 		}
+		// Fandom-end
 
 		$text .= Html::rawElement( 'p', null, $this->msg( 'cargo-cargotables-tablelist' )
 				->numParams( count( $tableNames ) )
@@ -543,7 +554,9 @@ class CargoTables extends IncludableSpecialPage {
 			}
 
 			$possibleReplacementTable = $tableName . '__NEXT';
-			$hasReplacementTable = CargoUtils::tableFullyExists( $possibleReplacementTable );
+			// Fandom-start
+			$hasReplacementTable = isset( $existingReplacementTables[$possibleReplacementTable] );
+			// Fandom-end
 			$actionLinks = $this->getActionLinksForTable( $tableName, false, $hasReplacementTable );
 
 			$numRowsText = $this->displayNumRowsForTable( $cdb, $tableName );

--- a/tests/selenium/.eslintrc.json
+++ b/tests/selenium/.eslintrc.json
@@ -2,5 +2,9 @@
 	"root": true,
 	"extends": [
 		"wikimedia/selenium"
-	]
+	],
+	"parserOptions": {
+		"ecmaVersion": 2020,
+		"sourceType": "module"
+	}
 }

--- a/tests/selenium/cargo-utils.js
+++ b/tests/selenium/cargo-utils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Utility functions for interacting with Cargo tables in E2E tests.
  */
@@ -50,4 +48,4 @@ class CargoTestUtils {
 	}
 }
 
-module.exports = new CargoTestUtils();
+export default new CargoTestUtils();

--- a/tests/selenium/pageobjects/cargotables.page.js
+++ b/tests/selenium/pageobjects/cargotables.page.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const Page = require( 'wdio-mediawiki/Page' );
+import Page from 'wdio-mediawiki/Page';
 
 /**
  * WDIO page object for Special:CargoTables.
@@ -58,4 +56,4 @@ class CargoTablesPage extends Page {
 	}
 }
 
-module.exports = new CargoTablesPage();
+export default new CargoTablesPage();

--- a/tests/selenium/pageobjects/drilldown.page.js
+++ b/tests/selenium/pageobjects/drilldown.page.js
@@ -1,6 +1,4 @@
-'use strict';
-
-const Page = require( 'wdio-mediawiki/Page' );
+import Page from 'wdio-mediawiki/Page';
 
 /**
  * WDIO page object for Special:Drilldown.
@@ -61,4 +59,4 @@ class DrilldownPage extends Page {
 	}
 }
 
-module.exports = new DrilldownPage();
+export default new DrilldownPage();

--- a/tests/selenium/specs/cargotables.spec.js
+++ b/tests/selenium/specs/cargotables.spec.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const assert = require( 'assert' ),
-	Api = require( 'wdio-mediawiki/Api' ),
-	CargoTablesPage = require( '../pageobjects/cargotables.page' ),
-	CargoTestUtils = require( '../cargo-utils' );
+import assert from 'assert';
+import Api from 'wdio-mediawiki/Api';
+import CargoTablesPage from '../pageobjects/cargotables.page.js';
+import CargoTestUtils from '../cargo-utils.js';
 
 describe( 'Special:CargoTables', () => {
 	before( async () => {

--- a/tests/selenium/specs/drilldown.spec.js
+++ b/tests/selenium/specs/drilldown.spec.js
@@ -1,9 +1,7 @@
-'use strict';
-
-const assert = require( 'assert' ),
-	Api = require( 'wdio-mediawiki/Api' ),
-	DrilldownPage = require( '../pageobjects/drilldown.page' ),
-	CargoTestUtils = require( '../cargo-utils' );
+import assert from 'assert';
+import Api from 'wdio-mediawiki/Api';
+import DrilldownPage from '../pageobjects/drilldown.page.js';
+import CargoTestUtils from '../cargo-utils.js';
 
 describe( 'Special:Drilldown', () => {
 	before( async () => {

--- a/tests/selenium/wdio-conf.js
+++ b/tests/selenium/wdio-conf.js
@@ -1,5 +1,3 @@
-'use strict';
+import { config as defaultConfig } from 'wdio-mediawiki/wdio-defaults.conf.js';
 
-const { config } = require( 'wdio-mediawiki/wdio-defaults.conf.js' );
-
-exports.config = { ...config };
+export const config = { ...defaultConfig };


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/UGC-6783
* https://github.com/Wikia/unified-platform/pull/22399

## Description
- Replaced table existence checks with a single select query from information_schema.
- Removed API permission check - it was added due to a Cargo update to v3.8.4. It shouldn't be like that as the LoL community extensively uses this API for analytics.
- Reverted disable ROAA changes.
- merge upstream fixes

## Acceptance Criteria
- [ ] test for new code.

## Who might be interested
